### PR TITLE
runtime metrics: refactor base tags to use runtime metrics

### DIFF
--- a/pkg/runtimemetrics/runtime_metrics_test.go
+++ b/pkg/runtimemetrics/runtime_metrics_test.go
@@ -256,26 +256,3 @@ func createLockContention(d time.Duration) {
 	}
 	wg.Wait()
 }
-func TestFormatByteSize(t *testing.T) {
-	t.Run("should format byte size correctly", func(t *testing.T) {
-		tests := []struct {
-			bytes    int64
-			expected string
-		}{
-			{0, "0 B"},
-			{1023, "1023 B"},
-			{1024, "1 KB"},
-			{1025, "1 KB"},
-			{1024 * 1024, "1 MB"},
-			{1024 * 1024 * 1024, "1 GB"},
-			{1024 * 1024 * 1024 * 1024, "1 TB"},
-			{1024 * 1024 * 1024 * 1024 * 1024, "1 PB"},
-			{1024 * 1024 * 1024 * 1024 * 1024 * 1024, "1 EB"},
-		}
-
-		for _, test := range tests {
-			result := formatByteSize(test.bytes)
-			assert.Equal(t, test.expected, result)
-		}
-	})
-}

--- a/pkg/runtimemetrics/tags.go
+++ b/pkg/runtimemetrics/tags.go
@@ -11,13 +11,13 @@ const gomemlimitMetricName = "/gc/gomemlimit:bytes"
 const gomaxProcsMetricName = "/sched/gomaxprocs:threads"
 
 func getBaseTags() []string {
-	baseTags := make([]string, 0, 3)
-
 	samples := []metrics.Sample{
 		{Name: gogcMetricName},
 		{Name: gomemlimitMetricName},
 		{Name: gomaxProcsMetricName},
 	}
+
+	baseTags := make([]string, 0, len(samples))
 
 	metrics.Read(samples)
 
@@ -65,5 +65,5 @@ func formatByteSize(bytes uint64) string {
 		div *= unit
 		exp++
 	}
-	return fmt.Sprintf(format, float64(bytes)/float64(div), string("KMGTPE"[exp]))
+	return fmt.Sprintf(format, float64(bytes)/float64(div), string("KMGTPE"[exp])+"i")
 }

--- a/pkg/runtimemetrics/tags.go
+++ b/pkg/runtimemetrics/tags.go
@@ -1,0 +1,69 @@
+package runtimemetrics
+
+import (
+	"fmt"
+	"math"
+	"runtime/metrics"
+)
+
+const gogcMetricName = "/gc/gogc:percent"
+const gomemlimitMetricName = "/gc/gomemlimit:bytes"
+const gomaxProcsMetricName = "/sched/gomaxprocs:threads"
+
+func getBaseTags() []string {
+	baseTags := make([]string, 0, 3)
+
+	samples := []metrics.Sample{
+		{Name: gogcMetricName},
+		{Name: gomemlimitMetricName},
+		{Name: gomaxProcsMetricName},
+	}
+
+	metrics.Read(samples)
+
+	for _, s := range samples {
+		switch s.Name {
+		case gogcMetricName:
+			gogc := s.Value.Uint64()
+			var goGCTagValue string
+			if gogc == math.MaxUint64 {
+				goGCTagValue = "off"
+			} else {
+				goGCTagValue = fmt.Sprintf("%d", gogc)
+			}
+			baseTags = append(baseTags, fmt.Sprintf("gogc:%s", goGCTagValue))
+		case gomemlimitMetricName:
+			gomemlimit := s.Value.Uint64()
+			var goMemLimitTagValue string
+			if gomemlimit == math.MaxInt64 {
+				goMemLimitTagValue = "unlimited"
+			} else {
+				// Convert GOMEMLIMIT to a human-readable string with the right byte unit
+				goMemLimitTagValue = formatByteSize(gomemlimit)
+			}
+			baseTags = append(baseTags, fmt.Sprintf("gomemlimit:%s", goMemLimitTagValue))
+		case gomaxProcsMetricName:
+			gomaxprocs := s.Value.Uint64()
+			baseTags = append(baseTags, fmt.Sprintf("gomaxprocs:%d", gomaxprocs))
+		}
+	}
+
+	return baseTags
+}
+
+// Function to format byte size with the right unit
+func formatByteSize(bytes uint64) string {
+	const (
+		unit   = 1024
+		format = "%.0f %sB"
+	)
+	if bytes < unit {
+		return fmt.Sprintf(format, float64(bytes), "")
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf(format, float64(bytes)/float64(div), string("KMGTPE"[exp]))
+}

--- a/pkg/runtimemetrics/tags_test.go
+++ b/pkg/runtimemetrics/tags_test.go
@@ -39,6 +39,8 @@ func TestGetBaseTags(t *testing.T) {
 			"154",
 		},
 		{
+			// GOGC=0 means that the GC is running continuously
+			// https://github.com/golang/go/issues/39419#issuecomment-640066815
 			"should return zero when gogc is zero",
 			0,
 			"0",
@@ -109,13 +111,13 @@ func TestFormatByteSize(t *testing.T) {
 		}{
 			{0, "0 B"},
 			{1023, "1023 B"},
-			{1024, "1 KB"},
-			{1025, "1 KB"},
-			{1024 * 1024, "1 MB"},
-			{1024 * 1024 * 1024, "1 GB"},
-			{1024 * 1024 * 1024 * 1024, "1 TB"},
-			{1024 * 1024 * 1024 * 1024 * 1024, "1 PB"},
-			{1024 * 1024 * 1024 * 1024 * 1024 * 1024, "1 EB"},
+			{1024, "1 KiB"},
+			{1025, "1 KiB"},
+			{1024 * 1024, "1 MiB"},
+			{1024 * 1024 * 1024, "1 GiB"},
+			{1024 * 1024 * 1024 * 1024, "1 TiB"},
+			{1024 * 1024 * 1024 * 1024 * 1024, "1 PiB"},
+			{1024 * 1024 * 1024 * 1024 * 1024 * 1024, "1 EiB"},
 		}
 
 		for _, test := range tests {

--- a/pkg/runtimemetrics/tags_test.go
+++ b/pkg/runtimemetrics/tags_test.go
@@ -1,0 +1,126 @@
+package runtimemetrics
+
+import (
+	"fmt"
+	"math"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func assertTagValue(t *testing.T, tagName, expectedTagValue string, actualTags []string) {
+	t.Helper()
+
+	expectedTag := fmt.Sprintf("%s:%s", tagName, expectedTagValue)
+
+	for _, tag := range actualTags {
+		if strings.HasPrefix(tag, fmt.Sprintf("%s:", tagName)) {
+			if tag != expectedTag {
+				t.Errorf("expected tag %s, got %s", expectedTag, tag)
+			}
+			return
+		}
+	}
+	t.Errorf("tag %s not found", tagName)
+}
+
+func TestGetBaseTags(t *testing.T) {
+	gogcTests := []struct {
+		name     string
+		gogc     int
+		expected string
+	}{
+		{
+			"should return the correct value for a specific gogc value",
+			154,
+			"154",
+		},
+		{
+			"should return zero when gogc is zero",
+			0,
+			"0",
+		},
+		{
+			"should return off when gogc if off",
+			-1,
+			"off",
+		},
+	}
+
+	for _, tt := range gogcTests {
+		t.Run(tt.name, func(t *testing.T) {
+			old := debug.SetGCPercent(tt.gogc)
+			defer debug.SetGCPercent(old)
+
+			tags := getBaseTags()
+			assertTagValue(t, "gogc", tt.expected, tags)
+		})
+	}
+
+	gomemlimitTests := []struct {
+		name       string
+		gomemlimit int64
+		expected   string
+	}{
+		{
+			"should return the correct value for a specific gomemlimit value",
+			123456789,
+			formatByteSize(123456789),
+		},
+		{
+			"should return zero when gomemlimit is zero",
+			0,
+			formatByteSize(0),
+		},
+		{
+			"should return unlimited when gomemlimit if off",
+			math.MaxInt64,
+			"unlimited",
+		},
+	}
+
+	for _, tt := range gomemlimitTests {
+		t.Run(tt.name, func(t *testing.T) {
+			old := debug.SetMemoryLimit(tt.gomemlimit)
+			defer debug.SetMemoryLimit(old)
+
+			tags := getBaseTags()
+			assertTagValue(t, "gomemlimit", tt.expected, tags)
+		})
+	}
+
+	t.Run("should return the correct value for a specific gomaxprocs value", func(t *testing.T) {
+		old := runtime.GOMAXPROCS(42)
+		defer runtime.GOMAXPROCS(old)
+
+		tags := getBaseTags()
+		assertTagValue(t, "gomaxprocs", "42", tags)
+	})
+}
+
+func TestFormatByteSize(t *testing.T) {
+	t.Run("should format byte size correctly", func(t *testing.T) {
+		tests := []struct {
+			bytes    uint64
+			expected string
+		}{
+			{0, "0 B"},
+			{1023, "1023 B"},
+			{1024, "1 KB"},
+			{1025, "1 KB"},
+			{1024 * 1024, "1 MB"},
+			{1024 * 1024 * 1024, "1 GB"},
+			{1024 * 1024 * 1024 * 1024, "1 TB"},
+			{1024 * 1024 * 1024 * 1024 * 1024, "1 PB"},
+			{1024 * 1024 * 1024 * 1024 * 1024 * 1024, "1 EB"},
+		}
+
+		for _, test := range tests {
+			result := formatByteSize(test.bytes)
+			assert.Equal(t, test.expected, result)
+		}
+	})
+}


### PR DESCRIPTION
Use runtime metrics for getting the values of gogc, gomemlimit and gomaxprocs.

Also adds tests for ensuring that the tags aligns with the expected value.