### PR TITLE
runtimemetrics: submit histograms as distribution metrics

### DIFF
--- a/pkg/runtimemetrics/histogram_test.go
+++ b/pkg/runtimemetrics/histogram_test.go
@@ -8,6 +8,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestHistogramToDistributionSamples(t *testing.T) {
+	t.Run("should correctly convert a given histogram to distribution samples", func(t *testing.T) {
+		h := &metrics.Float64Histogram{
+			Counts:  []uint64{1, 0, 10},
+			Buckets: []float64{0, 10, 20, 30},
+		}
+		s := distributionSamplesFromHist(h, nil)
+		assert.Len(t, s, 2)
+		assert.Equal(t, s, []distributionSample{
+			{Value: 5, Rate: 1},
+			{Value: 25, Rate: 0.1},
+		})
+	})
+}
+
 func TestHistogramSub(t *testing.T) {
 	t.Run("should correctly compute the substraction of two given histograms", func(t *testing.T) {
 		a := &metrics.Float64Histogram{

--- a/pkg/runtimemetrics/runtime_metrics_test.go
+++ b/pkg/runtimemetrics/runtime_metrics_test.go
@@ -152,6 +152,17 @@ func TestMetricKinds(t *testing.T) {
 					t.Errorf("missing %s metric", want)
 				}
 			}
+			found := false
+			want := ".gc_pauses.seconds"
+			for _, call := range mock.distributionSampleCall {
+				if strings.HasSuffix(call.name, want) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("missing %s metric", want)
+			}
 			rms.report()
 			// Note: No GC cycle is expected to occur here
 			require.Equal(t, len(summaries), len(mock.gaugeCall))
@@ -187,6 +198,8 @@ func TestSmoke(t *testing.T) {
 	// to catch severe regression. Might need to be updated in the future if
 	// lots of new metrics are added.
 	assert.InDelta(t, 87, len(mock.gaugeCall), 87/2) // typically 87
+
+	assert.Positive(t, len(mock.distributionSampleCall))
 }
 
 // BenchmarkReport is used to determine the overhead of collecting all metrics

--- a/pkg/runtimemetrics/statsd_client_mock_test.go
+++ b/pkg/runtimemetrics/statsd_client_mock_test.go
@@ -9,8 +9,9 @@ type statsdClientMock struct {
 	// Discard causes all calls to be discarded rather than tracked.
 	Discard bool
 
-	gaugeCall []statsdCall[float64]
-	countCall []statsdCall[int64]
+	gaugeCall              []statsdCall[float64]
+	countCall              []statsdCall[int64]
+	distributionSampleCall []statsdCall[[]float64]
 }
 
 // GaugeWithTimestamp implements partialStatsdClientInterface.
@@ -41,7 +42,20 @@ func (s *statsdClientMock) CountWithTimestamp(name string, value int64, tags []s
 	return nil
 }
 
-type statsdCall[T int64 | float64] struct {
+func (s *statsdClientMock) DistributionSamples(name string, values []float64, tags []string, rate float64) error {
+	if s.Discard {
+		return nil
+	}
+	s.distributionSampleCall = append(s.distributionSampleCall, statsdCall[[]float64]{
+		name:  name,
+		value: values,
+		tags:  tags,
+		rate:  rate,
+	})
+	return nil
+}
+
+type statsdCall[T int64 | float64 | []float64] struct {
 	name  string
 	value T
 	tags  []string


### PR DESCRIPTION
instead of pre-computing percentiles and submitting metrics as gauges, we submit them as distribution metrics using the statsd direct client. this allows us to get higher accuracy percentiles in the backend.

Co-authored-by: felix@datadoghq.com