### PR TITLE
refactor: mockCallsWithSuffix doesn't need t arg

### DIFF
--- a/pkg/runtimemetrics/runtime_metrics_test.go
+++ b/pkg/runtimemetrics/runtime_metrics_test.go
@@ -84,7 +84,7 @@ func TestMetricKinds(t *testing.T) {
 			runtime.GC()
 			runtime.GC()
 			rms.report()
-			calls := mockCallsWithSuffix(t, mock.gaugeCall, ".gc_cycles_total.gc_cycles")
+			calls := mockCallsWithSuffix(mock.gaugeCall, ".gc_cycles_total.gc_cycles")
 			require.Equal(t, 2, len(calls))
 			require.Greater(t, calls[1].value, calls[0].value)
 		})
@@ -108,11 +108,11 @@ func TestMetricKinds(t *testing.T) {
 
 			// With Go 1.22: mutex wait sometimes increments when calling runtime.GC().
 			// This does not seem to happen with Go <= 1.21
-			beforeCalls := mockCallsWithSuffix(t, mock.gaugeCall, ".sync_mutex_wait_total.seconds")
+			beforeCalls := mockCallsWithSuffix(mock.gaugeCall, ".sync_mutex_wait_total.seconds")
 			require.LessOrEqual(t, len(beforeCalls), 1)
 			createLockContention(100 * time.Millisecond)
 			rms.report()
-			afterCalls := mockCallsWithSuffix(t, mock.gaugeCall, ".sync_mutex_wait_total.seconds")
+			afterCalls := mockCallsWithSuffix(mock.gaugeCall, ".sync_mutex_wait_total.seconds")
 			require.Equal(t, len(beforeCalls)+1, len(afterCalls))
 			require.Greater(t, afterCalls[0].value, 0.0)
 		})

--- a/pkg/runtimemetrics/statsd_client_mock_test.go
+++ b/pkg/runtimemetrics/statsd_client_mock_test.go
@@ -76,8 +76,7 @@ func mockCallsWith[T int64 | float64 | []float64](calls []statsdCall[T], filter 
 	return results
 }
 
-func mockCallsWithSuffix[T int64 | float64 | []float64](t *testing.T, calls []statsdCall[T], suffix string) []statsdCall[T] {
-	t.Helper()
+func mockCallsWithSuffix[T int64 | float64 | []float64](calls []statsdCall[T], suffix string) []statsdCall[T] {
 	return mockCallsWith(calls, func(c statsdCall[T]) bool {
 		return strings.HasSuffix(c.name, suffix)
 	})
@@ -85,7 +84,7 @@ func mockCallsWithSuffix[T int64 | float64 | []float64](t *testing.T, calls []st
 
 func mockCallWithSuffix[T int64 | float64 | []float64](t *testing.T, calls []statsdCall[T], suffix string) statsdCall[T] {
 	t.Helper()
-	candidates := mockCallsWithSuffix(t, calls, suffix)
+	candidates := mockCallsWithSuffix(calls, suffix)
 	if len(candidates) != 1 {
 		t.Fatalf("expected 1 call with suffix %s, got %d", suffix, len(candidates))
 	}


### PR DESCRIPTION
See https://github.com/DataDog/go-runtime-metrics-internal/pull/16#discussion_r2124797761